### PR TITLE
Port to SIP 5

### DIFF
--- a/project.py
+++ b/project.py
@@ -1,0 +1,62 @@
+"""The build configuration file for PyQt-Qwt, used by sip."""
+
+import os
+from os.path import abspath, join
+from sipbuild import Option
+from pyqtbuild import PyQtBindings, PyQtProject
+import PyQt5
+
+
+class QwtProject(PyQtProject):
+    """The Qwt Project class."""
+
+    def __init__(self):
+        super().__init__()
+        self.bindings_factories = [QwtBindings]
+
+    def update(self, tool):
+        """Allows SIP to find PyQt5 .sip files."""
+        super().update(tool)
+        self.sip_include_dirs.append(join(PyQt5.__path__[0], 'bindings'))
+
+
+class QwtBindings(PyQtBindings):
+    """The Qwt Bindings class."""
+
+    def __init__(self, project):
+        super().__init__(project, name='Qwt',
+                         sip_file='qwt.sip',
+                         qmake_QT=['widgets'])
+
+    def get_options(self):
+        """Our custom options that a user can pass to sip-build."""
+        options = super().get_options()
+        options += [
+            Option('qwt_incdir',
+                   help='the directory containing the Qwt header file',
+                   metavar='DIR'),
+            Option('qwt_featuresdir',
+                   help='the directory containing the qwt.prf features file',
+                   metavar='DIR'),
+            Option('qwt_libdir',
+                   help='the directory containing the Qwt library',
+                   metavar='DIR'),
+            Option('qwt_lib',
+                   help='the Qwt library',
+                   metavar='LIB',
+                   default='qwt'),
+        ]
+        return options
+
+    def apply_user_defaults(self, tool):
+        """Apply values from user-configurable options."""
+        if self.qwt_incdir is not None:
+            self.include_dirs.append(self.qwt_incdir)
+        if self.qwt_featuresdir is not None:
+            os.environ['QMAKEFEATURES'] = abspath(self.qsci_features_dir)
+        if self.qwt_libdir is not None:
+            self.library_dirs.append(self.qwt_libdir)
+        if self.qwt_lib is not None:
+            self.libraries.append(self.qwt_lib)
+        self.define_macros.append('QWT_PYTHON_WRAPPER')
+        super().apply_user_defaults(tool)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["sip >=5", "PyQt-builder", "PyQt5"]
+build-backend = "sipbuild.api"
+
+[tool.sip.metadata]
+name = "qwt"
+version = "6.1.2"
+summary = "Python wrapper for Qwt6"
+description-file = "README.md"
+description-content-type = "text/markdown"
+home-page = "https://github.com/GauiStori/PyQt-Qwt"
+maintainer = "Gudjon I. Gudjonsson"
+maintainer-email = "gudjon@gudjon.org"
+license = "Qwt License 1.0"
+requires-dist = "PyQt5"
+
+[tool.sip.project]
+sip-files-dir = "sip"
+sdist-excludes = [
+  "version.sip",
+  ".git/*",
+  ".git/*/*",
+  ".git/*/*/*",
+  ".git/*/*/*/*",
+  ".git/*/*/*/*/*",
+  ".git/*/*/*/*/*/*",
+  ".git/*/*/*/*/*/*/*"
+]

--- a/sip/conversions.sip
+++ b/sip/conversions.sip
@@ -12,7 +12,7 @@
   if ((l = PyList_New(sipCpp->size())) == NULL)
     return NULL;
 
-  const sipMappedType* qvector_qreal = sipFindMappedType("QVector<qreal>");
+  const sipMappedType* qvector_qreal = sipFindType("QVector<qreal>");
 
   // Set the list elements.
   for (int i = 0; i < sipCpp->size(); ++i)
@@ -20,7 +20,7 @@
     QVector<qreal>* t = new QVector<qreal>(sipCpp->at(i));
     PyObject *tobj;
 
-    if ((tobj = sipConvertFromMappedType(t, qvector_qreal, sipTransferObj)) == NULL)
+    if ((tobj = sipConvertFromType(t, qvector_qreal, sipTransferObj)) == NULL)
     {
       Py_DECREF(l);
       delete t;
@@ -33,7 +33,7 @@
 %End
 
 %ConvertToTypeCode
-  const sipMappedType* qvector_qreal = sipFindMappedType("QVector<qreal>");
+  const sipMappedType* qvector_qreal = sipFindType("QVector<qreal>");
 
   // Check the type if that is all that is required.
   if (sipIsErr == NULL)
@@ -42,7 +42,7 @@
       return 0;
 
     for (int i = 0; i < PyList_GET_SIZE(sipPy); ++i)
-      if (!sipCanConvertToMappedType(PyList_GET_ITEM(sipPy, i), qvector_qreal, SIP_NOT_NONE))
+      if (!sipCanConvertToType(PyList_GET_ITEM(sipPy, i), qvector_qreal, SIP_NOT_NONE))
         return 0;
 
     return 1;
@@ -55,16 +55,16 @@
   {
     int state;
     //qreal *t = reinterpret_cast<qreal *>(sipConvertToInstance(PyList_GET_ITEM(sipPy, i), sipClass_qreal, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
-    QVector<qreal> * t = reinterpret_cast< QVector<qreal> * >(sipConvertToMappedType(PyList_GET_ITEM(sipPy, i), qvector_qreal, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
+    QVector<qreal> * t = reinterpret_cast< QVector<qreal> * >(sipConvertToType(PyList_GET_ITEM(sipPy, i), qvector_qreal, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
 
     if (*sipIsErr)
     {
-      sipReleaseMappedType(t, qvector_qreal, state);
+      sipReleaseType(t, qvector_qreal, state);
       delete ql;
       return 0;
     }
     ql->append(*t);
-    sipReleaseMappedType(t, qvector_qreal, state);
+    sipReleaseType(t, qvector_qreal, state);
   }
 
   *sipCppPtr = ql;

--- a/sip/qmap_convert.sip
+++ b/sip/qmap_convert.sip
@@ -1,6 +1,6 @@
 // QMap<double, QString> is implemented as a Python dictionary.
 
-%MappedType QMap<double,QString> /DocType="dict-of-double-QString"/
+%MappedType QMap<double,QString> /TypeHint="Dict[double,QString]", TypeHintValue="{}"/
 {
 %TypeHeaderCode
 #include <qwt_compass.h>


### PR DESCRIPTION
Hi @GauiStori!

This pull request includes two commits from your `sip5` branch, and the configuration for SIP 5 new buildsystem (`pyproject.toml` + `project.py`).

This way one can use `sip-build` to build the project, `sip-sdist` to generate an sdist for uploading to PyPI, etc.

Most of the options that one could pass to `configure.py` you can now pass to `sip-build`. On Debian, this command successfully builds the project:

    sip-build --qwt-incdir /usr/include/qwt --qwt-lib qwt-qt5

This way it should be also compatible with upcoming SIP 6 release.